### PR TITLE
fix: remove number requirement

### DIFF
--- a/src/Components/Calendar/Day.jsx
+++ b/src/Components/Calendar/Day.jsx
@@ -50,7 +50,7 @@ const Day = (props) => {
 };
 
 Day.propTypes = {
-  dayNumber: PropTypes.number.isRequired,
+  dayNumber: PropTypes.number,
 };
 
 export default Day;


### PR DESCRIPTION
this is needed because blank date boxes are used to fill before the first "date" of the month and those blank days do not have a number associated with them